### PR TITLE
feat(theme): palette-first brand config

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,12 @@ Story conventions (early stage):
 The site branding now comes from one source of truth: `src/pages/_brandConfig.ts`.
 
 1. Open `src/pages/_brandConfig.ts`.
-2. Update identity, organization, theme, links, SEO, and blog values.
+2. Update identity, organization, theme palette, and SEO defaults.
 3. Keep paths aligned with your configured `base` path in `astro.config.mjs`.
+
+Theme configuration is palette-first. Define `theme.palette.primary` and `theme.palette.secondary` as hex values and the full `50-950` scales are generated automatically.
+
+Page copy and page-specific metadata should stay in each page file under `src/pages/**`.
 
 For the complete typed example and current defaults, use `src/pages/_brandConfig.ts` directly.
 
@@ -177,7 +181,7 @@ Remove the old page file, because file-based routes take precedence over configu
 
 - Color tokens are exposed as CSS variables in `src/styles/global.css`.
 - Tailwind color utilities (`primary-*`, `secondary-*`) map to those variables in `tailwind.config.mjs`.
-- The active brand values are injected globally by `src/layouts/BaseLayout.astro`.
+- The active brand values are injected globally by `src/layouts/SiteShell.astro`.
 
 ## Resources Collection
 

--- a/src/components/foundations/BrandTokens/BrandTheme.utils.ts
+++ b/src/components/foundations/BrandTokens/BrandTheme.utils.ts
@@ -1,0 +1,161 @@
+import {
+  BRAND_COLOR_SHADES,
+  type BrandColorScale,
+  type BrandColorScaleOverrides,
+  type BrandTheme,
+  type BrandThemeInput,
+} from "./BrandToken.types";
+
+const LIGHT_MIX_BY_SHADE: Partial<
+  Record<(typeof BRAND_COLOR_SHADES)[number], number>
+> = {
+  "50": 0.92,
+  "100": 0.84,
+  "200": 0.72,
+  "300": 0.56,
+  "400": 0.32,
+};
+
+const DARK_MIX_BY_SHADE: Partial<
+  Record<(typeof BRAND_COLOR_SHADES)[number], number>
+> = {
+  "600": 0.12,
+  "700": 0.24,
+  "800": 0.38,
+  "900": 0.52,
+  "950": 0.68,
+};
+
+const clampByte = (value: number): number =>
+  Math.max(0, Math.min(255, Math.round(value)));
+
+const RGB_OR_HEX_PATTERN =
+  /^(?:#?(?:[a-fA-F0-9]{3}|[a-fA-F0-9]{6})|\d{1,3}\s+\d{1,3}\s+\d{1,3})$/;
+
+const parseRgbTriplet = (value: string): [number, number, number] => {
+  const normalized = value.trim();
+
+  if (!RGB_OR_HEX_PATTERN.test(normalized)) {
+    throw new Error(
+      `Invalid color value "${value}". Use hex (e.g. #3b82f6) or rgb triplet (e.g. 59 130 246).`,
+    );
+  }
+
+  if (normalized.includes(" ")) {
+    const channels = normalized
+      .split(/\s+/)
+      .map((token) => clampByte(Number(token)));
+
+    if (channels.length !== 3) {
+      throw new Error(
+        `Invalid rgb triplet "${value}". Use three channel values like "59 130 246".`,
+      );
+    }
+
+    const [r, g, b] = channels as [number, number, number];
+    return [r, g, b];
+  }
+
+  const hex = normalized.replace(/^#/, "");
+  const expandedHex =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((character) => `${character}${character}`)
+          .join("")
+      : hex;
+
+  const r = Number.parseInt(expandedHex.slice(0, 2), 16);
+  const g = Number.parseInt(expandedHex.slice(2, 4), 16);
+  const b = Number.parseInt(expandedHex.slice(4, 6), 16);
+
+  return [r, g, b];
+};
+
+const toRgbTriplet = ([r, g, b]: [number, number, number]): string =>
+  `${r} ${g} ${b}`;
+
+const toHex = ([r, g, b]: [number, number, number]): string =>
+  `#${[r, g, b]
+    .map((channel) => clampByte(channel).toString(16).padStart(2, "0"))
+    .join("")}`;
+
+const mixRgb = (
+  source: [number, number, number],
+  target: [number, number, number],
+  amount: number,
+): [number, number, number] => {
+  return [
+    clampByte(source[0] + (target[0] - source[0]) * amount),
+    clampByte(source[1] + (target[1] - source[1]) * amount),
+    clampByte(source[2] + (target[2] - source[2]) * amount),
+  ];
+};
+
+const mergeOverrides = (
+  scale: BrandColorScale,
+  overrides: BrandColorScaleOverrides | undefined,
+): BrandColorScale => {
+  if (!overrides) {
+    return scale;
+  }
+
+  const resolvedOverrides = Object.fromEntries(
+    Object.entries(overrides).map(([shade, value]) => [
+      shade,
+      toRgbTriplet(parseRgbTriplet(value)),
+    ]),
+  );
+
+  return {
+    ...scale,
+    ...resolvedOverrides,
+  } as BrandColorScale;
+};
+
+export const generateColorScale = (
+  baseColor: string,
+  overrides?: BrandColorScaleOverrides,
+): BrandColorScale => {
+  const baseRgb = parseRgbTriplet(baseColor);
+
+  const generatedScale = Object.fromEntries(
+    BRAND_COLOR_SHADES.map((shade) => {
+      if (shade === "500") {
+        return [shade, toRgbTriplet(baseRgb)];
+      }
+
+      const lightMixAmount = LIGHT_MIX_BY_SHADE[shade];
+      if (typeof lightMixAmount === "number") {
+        return [
+          shade,
+          toRgbTriplet(mixRgb(baseRgb, [255, 255, 255], lightMixAmount)),
+        ];
+      }
+
+      const darkMixAmount = DARK_MIX_BY_SHADE[shade] ?? 0;
+      return [shade, toRgbTriplet(mixRgb(baseRgb, [0, 0, 0], darkMixAmount))];
+    }),
+  ) as BrandColorScale;
+
+  return mergeOverrides(generatedScale, overrides);
+};
+
+export const resolveBrandTheme = (input: BrandThemeInput): BrandTheme => {
+  const primary = generateColorScale(
+    input.palette.primary,
+    input.overrides?.primary,
+  );
+  const secondary = generateColorScale(
+    input.palette.secondary,
+    input.overrides?.secondary,
+  );
+  const themeColor = input.themeColor ?? toHex(parseRgbTriplet(primary["600"]));
+
+  return {
+    primary,
+    secondary,
+    themeColor,
+    fonts: input.fonts,
+  };
+};

--- a/src/components/foundations/BrandTokens/BrandToken.types.ts
+++ b/src/components/foundations/BrandTokens/BrandToken.types.ts
@@ -1,17 +1,49 @@
-export type SocialPlatform = "github" | "twitter" | "linkedin";
+export const BRAND_COLOR_SHADES = [
+  "50",
+  "100",
+  "200",
+  "300",
+  "400",
+  "500",
+  "600",
+  "700",
+  "800",
+  "900",
+  "950",
+] as const;
 
-export interface BrandColorScale {
-  "50": string;
-  "100": string;
-  "200": string;
-  "300": string;
-  "400": string;
-  "500": string;
-  "600": string;
-  "700": string;
-  "800": string;
-  "900": string;
-  "950": string;
+export type BrandColorShade = (typeof BRAND_COLOR_SHADES)[number];
+
+export type BrandColorScale = Record<BrandColorShade, string>;
+
+export interface BrandThemePalette {
+  primary: string;
+  secondary: string;
+}
+
+export type BrandColorScaleOverrides = Partial<Record<BrandColorShade, string>>;
+
+export interface BrandThemeInput {
+  palette: BrandThemePalette;
+  themeColor?: string;
+  overrides?: {
+    primary?: BrandColorScaleOverrides;
+    secondary?: BrandColorScaleOverrides;
+  };
+  fonts?: {
+    sans: readonly string[];
+    mono: readonly string[];
+  };
+}
+
+export interface BrandTheme {
+  primary: BrandColorScale;
+  secondary: BrandColorScale;
+  themeColor: string;
+  fonts?: {
+    sans: readonly string[];
+    mono: readonly string[];
+  };
 }
 
 export interface BrandAddress {
@@ -20,42 +52,6 @@ export interface BrandAddress {
   addressRegion?: string;
   postalCode?: string;
   addressCountry?: string;
-}
-
-export interface BrandSocialLink {
-  platform: SocialPlatform;
-  url: string;
-}
-
-export interface BrandLink {
-  label: string;
-  href: string;
-}
-
-export interface BrandTokenItem {
-  name: string;
-  value: string;
-  description?: string;
-}
-
-export interface BrandTokenScale {
-  story: string;
-  source: "tailwind-default" | "custom";
-  tokens?: readonly BrandTokenItem[];
-}
-
-export interface BrandColorStory {
-  story: string;
-  roles: readonly {
-    name: string;
-    description: string;
-  }[];
-}
-
-export interface BrandDesignTokens {
-  colors: BrandColorStory;
-  typeScale: BrandTokenScale;
-  spacing: BrandTokenScale;
 }
 
 export interface BrandConfig {
@@ -77,30 +73,12 @@ export interface BrandConfig {
     socialProfiles: readonly string[];
     address?: BrandAddress;
   };
-  theme: {
-    primary: BrandColorScale;
-    secondary: BrandColorScale;
-    themeColor: string;
-    fonts?: {
-      sans: readonly string[];
-      mono: readonly string[];
-    };
-  };
-  designTokens: BrandDesignTokens;
-  links: {
-    primaryCtas: readonly BrandLink[];
-    appLinks: readonly BrandLink[];
-    social: readonly BrandSocialLink[];
-  };
+  theme: BrandTheme;
   seo: {
     titleTemplate: string;
     defaultDescription: string;
     robots: string;
     twitterCard: "summary" | "summary_large_image";
     twitterSite?: string;
-  };
-  blog: {
-    title: string;
-    description: string;
   };
 }

--- a/src/components/foundations/BrandTokens/BrandTokens.tsx
+++ b/src/components/foundations/BrandTokens/BrandTokens.tsx
@@ -77,22 +77,16 @@ export function BrandTokens({ brand }: BrandTokensProps): ReactElement {
       "monospace",
     ]),
   };
-  const roleMap = new Map(
-    brand.designTokens.colors.roles.map((role) => [
-      role.name,
-      role.description,
-    ]),
-  );
 
   const colorSections = [
     {
       name: "Primary",
-      role: roleMap.get("primary"),
+      role: "CTAs, links, and active states.",
       scale: brand.theme.primary,
     },
     {
       name: "Secondary",
-      role: roleMap.get("secondary"),
+      role: "Body text, borders, and neutral surfaces.",
       scale: brand.theme.secondary,
     },
   ];
@@ -108,7 +102,8 @@ export function BrandTokens({ brand }: BrandTokensProps): ReactElement {
             Color roles
           </h2>
           <p className="text-base text-secondary-600">
-            {brand.designTokens.colors.story}
+            Use primary for emphasis and secondary for structure and
+            readability.
           </p>
         </div>
         <div className="grid gap-6 lg:grid-cols-2">
@@ -150,7 +145,7 @@ export function BrandTokens({ brand }: BrandTokensProps): ReactElement {
             Type scale
           </h2>
           <p className="text-base text-secondary-600">
-            {brand.designTokens.typeScale.story}
+            The template uses Tailwind's default typography scale.
           </p>
         </div>
         <div className="rounded-2xl border border-secondary-200 bg-white p-6 shadow-sm">
@@ -176,7 +171,7 @@ export function BrandTokens({ brand }: BrandTokensProps): ReactElement {
         <div className="space-y-2">
           <h2 className="text-3xl font-semibold text-secondary-900">Spacing</h2>
           <p className="text-base text-secondary-600">
-            {brand.designTokens.spacing.story}
+            Layout spacing follows the default Tailwind spacing system.
           </p>
         </div>
         <div className="rounded-2xl border border-secondary-200 bg-white p-6 shadow-sm">

--- a/src/components/foundations/BrandTokens/index.ts
+++ b/src/components/foundations/BrandTokens/index.ts
@@ -1,3 +1,4 @@
 export { BrandTokens } from "./BrandTokens";
 export type { BrandTokensProps } from "./BrandTokens";
 export * from "./BrandToken.types";
+export * from "./BrandTheme.utils";

--- a/src/components/templates/HomeTemplate/HomeTemplate.stories.tsx
+++ b/src/components/templates/HomeTemplate/HomeTemplate.stories.tsx
@@ -7,83 +7,21 @@ const meta = {
   component: HomeTemplate,
   tags: ["autodocs"],
   args: {
-    brand: {
-      identity: {
-        siteName: "Idol or Bust",
-        tagline: "Simple website software for research projects",
-        siteUrl: "https://example.com",
-        language: "en",
-        locale: "en_US",
-        logoPath: "/logo.svg",
-        faviconPath: "/favicon.svg",
-        appleTouchIconPath: "/apple-touch-icon.png",
-        manifestPath: "/site.webmanifest",
-        defaultOgImagePath: "/og-image.png",
-      },
-      organization: {
-        name: "Idol or Bust",
-        legalName: "Idol or Bust Research Project",
-        socialProfiles: ["https://example.com"],
-      },
-      theme: {
-        primary: {
-          "50": "239 246 255",
-          "100": "219 234 254",
-          "200": "191 219 254",
-          "300": "147 197 253",
-          "400": "96 165 250",
-          "500": "59 130 246",
-          "600": "37 99 235",
-          "700": "29 78 216",
-          "800": "30 64 175",
-          "900": "30 58 138",
-          "950": "23 37 84",
-        },
-        secondary: {
-          "50": "248 250 252",
-          "100": "241 245 249",
-          "200": "226 232 240",
-          "300": "203 213 225",
-          "400": "148 163 184",
-          "500": "100 116 139",
-          "600": "71 85 105",
-          "700": "51 65 85",
-          "800": "30 41 59",
-          "900": "15 23 42",
-          "950": "2 6 23",
-        },
-        themeColor: "#2563eb",
-        fonts: {
-          sans: ["Inter", "system-ui", "sans-serif"],
-          mono: ["JetBrains Mono", "monospace"],
-        },
-      },
-      links: {
-        primaryCtas: [
-          { label: "Get started", href: "/start" },
-          { label: "Learn more", href: "/about" },
-        ],
-        appLinks: [],
-        social: [],
-      },
-      seo: {
-        titleTemplate: "%s | Idol or Bust",
-        defaultDescription:
-          "Simple website software for research projects that want to understand their user needs.",
-        robots: "index,follow",
-        twitterCard: "summary_large_image",
-      },
-      blog: {
-        title: "Idol or Bust Blog",
-        description:
-          "Latest updates and insights from the Idol or Bust project.",
-      },
-    },
+    siteDescription:
+      "Simple website software for research projects that want to understand their user needs.",
     content: {
       hero: {
         title: "Research with clarity",
         highlight: "clarity",
         descriptionSuffix: "Built for teams who need honest insights.",
+        primaryAction: {
+          label: "Get started",
+          href: "/start",
+        },
+        secondaryAction: {
+          label: "Learn more",
+          href: "/about",
+        },
       },
       sections: {
         featuresTitle: "What you get",

--- a/src/components/templates/HomeTemplate/HomeTemplate.tsx
+++ b/src/components/templates/HomeTemplate/HomeTemplate.tsx
@@ -6,19 +6,19 @@ import { withBase } from "@/components/utils/with-base";
 import type { HomeTemplateProps } from "./HomeTemplate.types";
 
 export const HomeTemplate = ({
-  brand,
+  siteDescription,
   content,
   features,
 }: HomeTemplateProps) => {
-  const primaryCta = brand.links.primaryCtas.at(0);
-  const secondaryCta = brand.links.primaryCtas.at(1);
+  const primaryCta = content.hero.primaryAction;
+  const secondaryCta = content.hero.secondaryAction;
 
   return (
     <>
       <HomeHero
         title={content.hero.title}
         highlight={content.hero.highlight}
-        description={`${brand.seo.defaultDescription} ${content.hero.descriptionSuffix}`}
+        description={`${siteDescription} ${content.hero.descriptionSuffix}`}
         primaryAction={
           primaryCta ? (
             <Button

--- a/src/components/templates/HomeTemplate/HomeTemplate.types.ts
+++ b/src/components/templates/HomeTemplate/HomeTemplate.types.ts
@@ -1,71 +1,8 @@
 import type { FeatureItem } from "@/components/molecules/FeatureGrid/FeatureGrid.types";
 
-interface BrandColorScale {
-  "50": string;
-  "100": string;
-  "200": string;
-  "300": string;
-  "400": string;
-  "500": string;
-  "600": string;
-  "700": string;
-  "800": string;
-  "900": string;
-  "950": string;
-}
-
-export interface HomeTemplateBrand {
-  identity: {
-    siteName: string;
-    tagline: string;
-    siteUrl: string;
-    language: string;
-    locale: string;
-    logoPath: string;
-    faviconPath: string;
-    appleTouchIconPath: string;
-    manifestPath: string;
-    defaultOgImagePath: string;
-  };
-  organization: {
-    name: string;
-    legalName?: string;
-    socialProfiles: readonly string[];
-  };
-  theme: {
-    primary: BrandColorScale;
-    secondary: BrandColorScale;
-    themeColor: string;
-    fonts?: {
-      sans: readonly string[];
-      mono: readonly string[];
-    };
-  };
-  links: {
-    primaryCtas: readonly {
-      label: string;
-      href: string;
-    }[];
-    appLinks: readonly {
-      label: string;
-      href: string;
-    }[];
-    social: readonly {
-      platform: string;
-      url: string;
-    }[];
-  };
-  seo: {
-    titleTemplate: string;
-    defaultDescription: string;
-    robots: string;
-    twitterCard: "summary" | "summary_large_image";
-    twitterSite?: string;
-  };
-  blog: {
-    title: string;
-    description: string;
-  };
+export interface HomeHeroAction {
+  label: string;
+  href: string;
 }
 
 export interface HomeTemplateContent {
@@ -73,6 +10,8 @@ export interface HomeTemplateContent {
     title: string;
     highlight: string;
     descriptionSuffix: string;
+    primaryAction?: HomeHeroAction;
+    secondaryAction?: HomeHeroAction;
   };
   sections: {
     featuresTitle: string;
@@ -86,7 +25,7 @@ export interface HomeTemplateContent {
 }
 
 export interface HomeTemplateProps {
-  brand: HomeTemplateBrand;
+  siteDescription: string;
   content: HomeTemplateContent;
   features: readonly FeatureItem[];
 }

--- a/src/components/templates/HomeTemplate/index.ts
+++ b/src/components/templates/HomeTemplate/index.ts
@@ -1,6 +1,6 @@
 export { HomeTemplate } from "./HomeTemplate";
 export type {
-  HomeTemplateBrand,
+  HomeHeroAction,
   HomeTemplateContent,
   HomeTemplateProps,
 } from "./HomeTemplate.types";

--- a/src/pages/_brandConfig.ts
+++ b/src/pages/_brandConfig.ts
@@ -1,4 +1,7 @@
-import type { BrandConfig } from "@/components/foundations/BrandTokens/BrandToken.types";
+import {
+  resolveBrandTheme,
+  type BrandConfig,
+} from "@/components/foundations/BrandTokens";
 
 export const BRAND_CONFIG: BrandConfig = {
   identity: {
@@ -18,82 +21,22 @@ export const BRAND_CONFIG: BrandConfig = {
     legalName: "Idol or Bust Research Project",
     socialProfiles: ["https://github.com/riehlegroup/idolbust"],
   },
-  theme: {
-    primary: {
-      "50": "239 246 255",
-      "100": "219 234 254",
-      "200": "191 219 254",
-      "300": "147 197 253",
-      "400": "96 165 250",
-      "500": "59 130 246",
-      "600": "37 99 235",
-      "700": "29 78 216",
-      "800": "30 64 175",
-      "900": "30 58 138",
-      "950": "23 37 84",
-    },
-    secondary: {
-      "50": "248 250 252",
-      "100": "241 245 249",
-      "200": "226 232 240",
-      "300": "203 213 225",
-      "400": "148 163 184",
-      "500": "100 116 139",
-      "600": "71 85 105",
-      "700": "51 65 85",
-      "800": "30 41 59",
-      "900": "15 23 42",
-      "950": "2 6 23",
+  theme: resolveBrandTheme({
+    palette: {
+      primary: "#3b82f6",
+      secondary: "#64748b",
     },
     themeColor: "#2563eb",
     fonts: {
       sans: ["Inter", "system-ui", "sans-serif"],
       mono: ["JetBrains Mono", "monospace"],
     },
-  },
-  designTokens: {
-    colors: {
-      story:
-        "Use primary for calls to action and links, secondary for typography and surface contrast. Keep primary usage focused to preserve emphasis.",
-      roles: [
-        { name: "primary", description: "CTAs, links, active states." },
-        {
-          name: "secondary",
-          description: "Text, borders, neutral backgrounds.",
-        },
-      ],
-    },
-    typeScale: {
-      story:
-        "Rely on Tailwind's default type scale for now; adjust later if brand voice changes.",
-      source: "tailwind-default",
-    },
-    spacing: {
-      story:
-        "Use Tailwind's default spacing scale to keep layout consistent and predictable.",
-      source: "tailwind-default",
-    },
-  },
-  links: {
-    primaryCtas: [
-      { label: "Learn More", href: "/about" },
-      { label: "Read Blog", href: "/blog" },
-    ],
-    appLinks: [],
-    social: [
-      { platform: "github", url: "https://github.com/riehlegroup/idolbust" },
-    ],
-  },
+  }),
   seo: {
     titleTemplate: "%s | {siteName}",
     defaultDescription:
       "Simple website software for research projects that want to understand their user needs",
     robots: "index,follow",
     twitterCard: "summary_large_image",
-  },
-  blog: {
-    title: "Idol or Bust Blog",
-    description:
-      "Latest updates and insights from the Idol or Bust research project.",
   },
 };

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,9 +1,11 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import { AboutTemplate } from '@/components/templates';
-import { BRAND_CONFIG } from '@/pages/_brandConfig';
+import type { SocialLink } from '@/components/organisms/SocialLinks';
 
-const socialLinks = BRAND_CONFIG.links.social;
+const socialLinks: readonly SocialLink[] = [
+  { platform: 'github', url: 'https://github.com/riehlegroup/idolbust' },
+];
 
 const pageTitle = "About";
 const pageDescription = "Learn about the Idol or Bust research project and our mission.";
@@ -12,19 +14,17 @@ const heroSection = {
   body: "Idol or Bust is a research project focused on developing simple website software that helps other research projects understand their user needs.",
 };
 const textSections = [
-    {
-      title: "Our Mission",
-      body: "We believe that understanding users is the foundation of successful research projects. Our goal is to provide lightweight, maintainable tools that help researchers gather insights and make data-driven decisions.",
-    },
-    {
-      title: "Our Approach",
-      body: "We follow a user-centered design process, constantly iterating based on feedback from the research community. Our tools are built with maintainability in mind, ensuring they can evolve with changing needs.",
-    },
+  {
+    title: "Our Mission",
+    body: "We believe that understanding users is the foundation of successful research projects. Our goal is to provide lightweight, maintainable tools that help researchers gather insights and make data-driven decisions.",
+  },
+  {
+    title: "Our Approach",
+    body: "We follow a user-centered design process, constantly iterating based on feedback from the research community. Our tools are built with maintainability in mind, ensuring they can evolve with changing needs.",
+  },
 ];
 const teamTitle = "Research Team";
 const socialLabel = "Follow us:";
-
-
 export const teamMembers = [
   {
     name: "Jane Doe",
@@ -42,8 +42,6 @@ export const teamMembers = [
     bio: "Building tools that help researchers understand their users.",
   },
 ];
-
-
 ---
 
 <BaseLayout

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,7 +4,6 @@ import { BlogIndexTemplate } from '@/components/templates';
 import { getCollection } from 'astro:content';
 import { withBase } from "@/components/utils/with-base";
 import { formatDate, getBlogSlug, getPublishedPosts, type BlogEntry } from '@/utils/blog';
-import { BRAND_CONFIG } from '@/pages/_brandConfig';
 
 const posts = getPublishedPosts(await getCollection('blog')).map(
   (post: BlogEntry) => ({
@@ -21,11 +20,12 @@ const posts = getPublishedPosts(await getCollection('blog')).map(
 );
 
 const pageTitle = "Blog";
+const pageDescription = "Latest updates and insights from the Idol or Bust research project.";
 const emptyStateText = "No posts yet. Check back soon!";
 
 ---
 
-<BaseLayout title={pageTitle} description={BRAND_CONFIG.blog.description}>
+<BaseLayout title={pageTitle} description={pageDescription}>
   <BlogIndexTemplate
     title={pageTitle}
     emptyState={emptyStateText}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,10 +6,18 @@ import { BRAND_CONFIG } from '@/pages/_brandConfig';
 const { identity, seo } = BRAND_CONFIG;
 
 const hero = {
-    title: "Understanding Your",
-    highlight: "User Needs",
-    descriptionSuffix: "through modern methodologies and tools.",
-  };
+  title: "Understanding Your",
+  highlight: "User Needs",
+  descriptionSuffix: "through modern methodologies and tools.",
+  primaryAction: {
+    label: "Learn More",
+    href: "/about",
+  },
+  secondaryAction: {
+    label: "Read Blog",
+    href: "/blog",
+  },
+};
 const featuresTitle = "What We Offer";
 const features = [
   {
@@ -40,7 +48,7 @@ const callToAction = {
 
 <BaseLayout title={identity.siteName} description={seo.defaultDescription}>
   <HomeTemplate
-    brand={BRAND_CONFIG}
+    siteDescription={seo.defaultDescription}
     content={{
       hero,
       sections: {

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -5,12 +5,16 @@ import { withBase } from "@/components/utils/with-base";
 import { getBlogSlug, getPublishedPosts } from "@/utils/blog";
 import { BRAND_CONFIG } from "@/pages/_brandConfig";
 
+const BLOG_RSS_TITLE = "Idol or Bust Blog";
+const BLOG_RSS_DESCRIPTION =
+  "Latest updates and insights from the Idol or Bust research project.";
+
 export async function GET(context: APIContext) {
   const posts = getPublishedPosts(await getCollection("blog"));
 
   return rss({
-    title: BRAND_CONFIG.blog.title,
-    description: BRAND_CONFIG.blog.description,
+    title: BLOG_RSS_TITLE,
+    description: BLOG_RSS_DESCRIPTION,
     site: context.site ?? BRAND_CONFIG.identity.siteUrl,
     items: posts.map((post) => ({
       title: post.data.title,


### PR DESCRIPTION
## Summary
- Generate full primary/secondary scales from two palette colors.
- Keep brand config global-only and move page-specific content into page files.

Closes #28.